### PR TITLE
Calculates Content-Length in bytes instead of characters

### DIFF
--- a/lib/staticTransform.js
+++ b/lib/staticTransform.js
@@ -117,7 +117,7 @@ function createMiddleware(options) {
 function writeOut(code, res, out, headers, options) {
   // Set length if necessary
   if (!headers['Content-Length']) {
-    headers['Content-Length'] = out.length;
+    headers['Content-Length'] = Buffer.byteLength(out);
   }
   res.writeHead(code, headers);
   if (code === 200) {


### PR DESCRIPTION
Calculating `Content-Length` using the simple `.length` property gives the content's length in characters, which in the presence of any multi-byte characters isn't the correct way to specify `Content-Length`; this leads to truncated output of files containing multi-byte chars. This changeset ensures that `Content-Length` is calculated in bytes, using `Buffer.byteLength`.
