### PR TITLE
For a 200 successful response, set the headers implicitly

### DIFF
--- a/lib/staticTransform.js
+++ b/lib/staticTransform.js
@@ -124,10 +124,15 @@ function writeOut(code, res, out, headers, options) {
   if (!headers['Content-Length']) {
     headers['Content-Length'] = Buffer.byteLength(out);
   }
-  res.writeHead(code, headers);
   if (code === 200) {
+    for (var k in headers) {
+      if (headers.hasOwnProperty(k)) {
+        res.setHeader(k, headers[k]);
+      }
+    }
     res.end(out, options.encoding);
   } else {
+    res.writeHead(code, headers);
     res.end();
   }
 }


### PR DESCRIPTION
Using `res.setHeader()` instead of `res.writeHead()` means that other middleware are free to modify the headers as well if required. For example, the `express.compress()` middleware was unable to apply gzip to files from connect-static-transform since the headers were already sent; with this change made, `express.compress()` works fine alongside connect-static-transform middleware.

I left the headers set explicitly, with `res.writeHead()`, for error responses since those are less likely to need gzip or other middleware.

(Allowing gzipping on transformed files is kind of important, considering they'll often be JavaScript!)
