### PR TITLE
Move to non-vulnerable version of connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-static-transform",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A connect middleware which allows transformation of static files before serving them.",
   "main": "lib/staticTransform.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-static-transform",
-  "version": "0.9.0",
+  "version": "0.8.0",
   "description": "A connect middleware which allows transformation of static files before serving them.",
   "main": "lib/staticTransform.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A connect middleware which allows transformation of static files before serving them.",
   "main": "lib/staticTransform.js",
   "dependencies": {
-    "connect": "~2.7.2"
+    "connect": "~2.8.1"
   },
   "devDependencies": {
     "snockets": "1.3.8",


### PR DESCRIPTION
nsp reports version 2.7.2 as having a number of security vulnerabilities as reported in #8. This moves to the first non-vulnerable version of connect.